### PR TITLE
Refactor todo data flow for scalability

### DIFF
--- a/App.js
+++ b/App.js
@@ -1,43 +1,45 @@
-
+import { useCallback, useEffect, useState } from "react";
 import { SafeAreaView } from "react-native";
-import Home from "./app/screens/Home";
+import AsyncStorage from "@react-native-async-storage/async-storage";
 import { NavigationContainer } from "@react-navigation/native";
 import { createStackNavigator } from "@react-navigation/stack";
+import Home from "./app/screens/Home";
 import About from "./app/screens/About";
 import Navbar from "./app/components/Navbar";
-import AsyncStorage from "@react-native-async-storage/async-storage";
 import { ThemeContext } from "./app/Contexts/ThemeContext";
-import { useEffect, useState } from "react";
+
+const Stack = createStackNavigator();
+const THEME_STORAGE_KEY = "theme";
 
 export default function App() {
-   const Stack = createStackNavigator();
-   const [currentMode, setCurrentMode] = useState('false')
-   const currentTheme = async()=>{
-    const mode = await AsyncStorage.getItem('theme');
-    setCurrentMode(mode?mode:'false')
-   }
-   useEffect(()=>{
-    currentTheme();
-   }, [currentMode])
-   async function themeHandler () {
-    const mode = await AsyncStorage.getItem('theme')
-    const newMode = mode === 'true'  ? 'false':'true';
-    await AsyncStorage.setItem('theme', newMode);
-    setCurrentMode(newMode)
-  }
+  const [currentMode, setCurrentMode] = useState("false");
+
+  useEffect(() => {
+    async function loadTheme() {
+      const storedMode = await AsyncStorage.getItem(THEME_STORAGE_KEY);
+      setCurrentMode(storedMode ?? "false");
+    }
+
+    loadTheme();
+  }, []);
+
+  const themeHandler = useCallback(async () => {
+    const nextMode = currentMode === "true" ? "false" : "true";
+    await AsyncStorage.setItem(THEME_STORAGE_KEY, nextMode);
+    setCurrentMode(nextMode);
+  }, [currentMode]);
 
   return (
-   <SafeAreaView style={{flex:1, pointerEvents:'auto'}}>
-    <ThemeContext.Provider value={{themeHandler, currentMode}}>
-     <NavigationContainer>
-      <Navbar/>
-         <Stack.Navigator initialRouteName="Home" screenOptions={{headerShown:false}}>
-          <Stack.Screen name="Home" component={Home} />
-          <Stack.Screen name="About" component={About} />
-         </Stack.Navigator>
-     </NavigationContainer>
-     </ThemeContext.Provider>
-   </SafeAreaView>
+    <SafeAreaView style={{ flex: 1, pointerEvents: "auto" }}>
+      <ThemeContext.Provider value={{ themeHandler, currentMode }}>
+        <NavigationContainer>
+          <Navbar />
+          <Stack.Navigator initialRouteName="Home" screenOptions={{ headerShown: false }}>
+            <Stack.Screen name="Home" component={Home} />
+            <Stack.Screen name="About" component={About} />
+          </Stack.Navigator>
+        </NavigationContainer>
+      </ThemeContext.Provider>
+    </SafeAreaView>
   );
-
-  }
+}

--- a/app/hooks/useTodos.js
+++ b/app/hooks/useTodos.js
@@ -1,0 +1,71 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { Keyboard } from "react-native";
+import { createTodo, removeTodo, subscribeToTodos } from "../services/todoService";
+
+export function useTodos() {
+  const [todo, setTodo] = useState("");
+  const [todos, setTodos] = useState([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [deletingId, setDeletingId] = useState(null);
+
+  useEffect(() => {
+    const unsubscribe = subscribeToTodos(
+      (nextTodos) => {
+        setTodos(nextTodos);
+        setIsLoading(false);
+      },
+      () => {
+        setIsLoading(false);
+        alert("Error while fetching todos. Please try again.");
+      }
+    );
+
+    return unsubscribe;
+  }, []);
+
+  const addTodo = useCallback(async () => {
+    const trimmedTodo = todo.trim();
+
+    if (!trimmedTodo) {
+      alert("The field should not be empty! Please try again.");
+      return;
+    }
+
+    try {
+      setIsSubmitting(true);
+      await createTodo(trimmedTodo);
+      setTodo("");
+      Keyboard.dismiss();
+    } catch (error) {
+      alert("There was an internal server error while adding a todo.");
+    } finally {
+      setIsSubmitting(false);
+    }
+  }, [todo]);
+
+  const deleteTodo = useCallback(async (id) => {
+    try {
+      setDeletingId(id);
+      await removeTodo(id);
+    } catch (error) {
+      alert("There was an internal server error while deleting a todo!");
+    } finally {
+      setDeletingId((currentId) => (currentId === id ? null : currentId));
+    }
+  }, []);
+
+  return useMemo(
+    () => ({
+      todo,
+      setTodo,
+      todos,
+      isLoading,
+      isSubmitting,
+      deletingId,
+      addTodo,
+      deleteTodo,
+    }),
+    [todo, todos, isLoading, isSubmitting, deletingId, addTodo, deleteTodo]
+  );
+}

--- a/app/screens/Home.jsx
+++ b/app/screens/Home.jsx
@@ -1,29 +1,16 @@
-import { useContext, useEffect, useState } from "react";
-import {
-  StyleSheet,
-  Text,
-  TextInput,
-  View,
-  Pressable,
-  ScrollView,
-  Keyboard,
-} from "react-native";
+import { useContext } from "react";
+import { Pressable, ScrollView, StyleSheet, Text, TextInput, View } from "react-native";
 import { ThemeContext } from "../Contexts/ThemeContext";
-import { db } from "../../firebase.config";
+import { useTodos } from "../hooks/useTodos";
 
-
-export default function Home() {
-  const { currentMode } = useContext(ThemeContext);
-  // style sheet
-  const styles = StyleSheet.create({
+const createStyles = (currentMode) =>
+  StyleSheet.create({
     todos: {
-      display: "flex",
-      justifyContent: "space-between",
       alignItems: "center",
-      borderBlockColor: "gray",
-      height: "auto",
-      width: "auto",
+      justifyContent: "space-between",
       marginTop: 55,
+      width: "100%",
+      paddingBottom: 24,
     },
     container: {
       flex: 1,
@@ -36,13 +23,11 @@ export default function Home() {
       fontSize: 25,
     },
     form: {
-      flex: 1 / 4,
       marginTop: 32,
-      display: "flex",
+      flexDirection: "row",
       justifyContent: "space-between",
       padding: 3,
       alignItems: "center",
-      flexDirection: "row",
       position: "absolute",
       zIndex: 99,
     },
@@ -51,68 +36,47 @@ export default function Home() {
       borderRadius: 12,
       padding: 8,
       width: 250,
-      margin: "5",
+      margin: 5,
     },
     button: {
-      backgroundColor: `${currentMode === "false" ? "dodgerblue" : "black"}`,
-      fontSize: 12,
-      color: "white",
+      backgroundColor: currentMode === "false" ? "dodgerblue" : "black",
       borderRadius: 15,
       padding: 12,
-      width: 50,
-      margin: 2,
+      minWidth: 60,
+      alignItems: "center",
+    },
+    todoCard: {
+      flexDirection: "row",
+      justifyContent: "space-between",
+      backgroundColor: currentMode === "false" ? "dodgerblue" : "black",
+      padding: 10,
+      borderRadius: 13,
+      alignItems: "center",
+      maxWidth: "80%",
+      minWidth: "80%",
+      marginTop: 12,
+    },
+    todoText: {
+      color: "white",
+      padding: 5,
+      flex: 1,
+    },
+    deleteButton: {
+      backgroundColor: "red",
+      padding: 5,
+      borderRadius: 8,
+    },
+    statusText: {
+      color: "black",
+      fontWeight: "800",
+      marginTop: 80,
     },
   });
-  const [isDeleting, setIsDeleting] = useState(null);
-  const [isLoading, setIsLoading] = useState(false);
-  const [todo, setTodo] = useState("");
-  const [todos, setTodos] = useState([]);
-  //adding the todo
-  const addTodo = async () => {
-    if (!todo && todo === "") {
-      return alert("The field should not be empty! please try again");
-    }
-    const collectionRef = db.collection("todos");
-    await collectionRef.add({ todo });
-    setTodo("");
-    Keyboard.dismiss();
-    fetchTodos();
-    return;
-  };
-  //get todos
-  async function fetchTodos() {
-    try {
-      setIsLoading(true);
-      const collectionRef = db.collection('todos');
-      const data = await collectionRef.get();
-      console.log(data.docs)
-      setTodos(data.docs);
-      setIsLoading(false)
-      return;
-    } catch (error) {
-      alert("error while fetching the data!");
-      return;
-    }
-  }
-  useEffect(() => {
-    fetchTodos();
-  }, [])
-  //deleting the todo
-  const deleteTodo = async (id) => {
-    try {
-      setIsDeleting(id)
-      const collectionRef = db.collection('todos');
-      const docRef = collectionRef.doc(id);
-      await docRef.delete();
-      setIsDeleting(null);
-      fetchTodos();
-      return;
-    } catch (error) {
-      alert('There was an internal server \n error while deleting todo!');
-      setIsDeleting(false)
-      return;
-    }
-  };
+
+export default function Home() {
+  const { currentMode } = useContext(ThemeContext);
+  const { todo, setTodo, todos, isLoading, isSubmitting, deletingId, addTodo, deleteTodo } = useTodos();
+  const styles = createStyles(currentMode);
 
   return (
     <View style={styles.container}>
@@ -120,57 +84,40 @@ export default function Home() {
       <View style={styles.form}>
         <TextInput
           value={todo}
-          onChangeText={(value) => setTodo(value)}
+          onChangeText={setTodo}
           style={styles.field}
           inputMode="text"
+          placeholder="Add a todo"
         />
-        <View style={styles.button}>
-          <Pressable onPress={addTodo}>
-            <Text style={{ color: "white" }}>Add</Text>
-          </Pressable>
-        </View>
+        <Pressable style={styles.button} onPress={addTodo} disabled={isSubmitting}>
+          <Text style={{ color: "white" }}>{isSubmitting ? "..." : "Add"}</Text>
+        </Pressable>
       </View>
       <ScrollView
         contentContainerStyle={styles.todos}
-        scrollEnabled
         showsHorizontalScrollIndicator={false}
         showsVerticalScrollIndicator={false}
       >
-        {!isLoading ? todos?.map((todo) => {
-          return (
-            <View
-              key={todo.id}
-              style={{
-                display: "flex",
-                flexDirection: "row",
-                justifyContent: "space-between",
-                backgroundColor: `${currentMode === "false" ? "dodgerblue" : "black"
-                  }`,
-                padding: 10,
-                borderRadius: 13,
-                alignItems: "center",
-                maxWidth: "80%",
-                minWidth: "80%",
-                height: "auto",
-                marginTop: 12,
-              }}
-            >
-              <Text style={{ color: "white", padding: 5 }}>{isDeleting === todo.id ? <Text>Deleting.....</Text> : todo.data()?.todo}</Text>
+        {isLoading ? (
+          <Text style={styles.statusText}>Loading...</Text>
+        ) : (
+          todos.map((todoItem) => (
+            <View key={todoItem.id} style={styles.todoCard}>
+              <Text style={styles.todoText}>
+                {deletingId === todoItem.id ? "Deleting..." : todoItem.todo}
+              </Text>
               <Pressable
-                style={{ backgroundColor: "red", padding: 5 }}
-                onPress={() => deleteTodo(todo?.id)}
+                style={styles.deleteButton}
+                onPress={() => deleteTodo(todoItem.id)}
+                disabled={deletingId === todoItem.id}
               >
-                <Text style={{ color: "white", borderRadius: 12 }}>{isDeleting === todo.id ? <Text>Deleting.....</Text> : 'Delete'}</Text>
+                <Text style={{ color: "white" }}>
+                  {deletingId === todoItem.id ? "Deleting..." : "Delete"}
+                </Text>
               </Pressable>
             </View>
-          );
-        }) :
-          <View
-
-          >
-            <Text style={{ color: 'black', fontWeight: '800' }}>Loading.................</Text>
-          </View>
-        }
+          ))
+        )}
       </ScrollView>
     </View>
   );

--- a/app/services/todoService.js
+++ b/app/services/todoService.js
@@ -1,0 +1,37 @@
+import { db } from "../../firebase.config";
+
+const todosCollection = db.collection("todos");
+
+const mapSnapshot = (snapshot) =>
+  snapshot.docs.map((doc) => ({
+    id: doc.id,
+    ...doc.data(),
+  }));
+
+export function subscribeToTodos(onUpdate, onError) {
+  return todosCollection.onSnapshot(
+    (snapshot) => {
+      onUpdate(mapSnapshot(snapshot));
+    },
+    (error) => {
+      onError?.(error);
+    }
+  );
+}
+
+export async function createTodo(value) {
+  const trimmedValue = value.trim();
+
+  if (!trimmedValue) {
+    throw new Error("Todo value is required");
+  }
+
+  await todosCollection.add({
+    todo: trimmedValue,
+    createdAt: new Date().toISOString(),
+  });
+}
+
+export async function removeTodo(id) {
+  await todosCollection.doc(id).delete();
+}

--- a/firebase.config.js
+++ b/firebase.config.js
@@ -22,7 +22,7 @@ const firebaseConfig = {
 
 // Initialize Firebase
  
- const app = firebase.initializeApp(firebaseConfig);
+const app = firebase.apps.length ? firebase.app() : firebase.initializeApp(firebaseConfig);
 
 // export const db = getFirestore(app);
 export const db = app.firestore()


### PR DESCRIPTION
### Motivation
- Separate concerns so todo CRUD, realtime subscription and UI state are decoupled and easier to extend. 
- Make the Home screen leaner by moving data logic into reusable services/hooks and improving loading/submitting/deleting feedback. 
- Prevent double-initialization of Firebase and simplify theme persistence so app reloads behave predictably.

### Description
- Add a service layer at `app/services/todoService.js` that centralizes Firestore access and maps snapshots to plain todo objects. 
- Add a reusable hook `app/hooks/useTodos.js` that exposes `todo`, `setTodo`, `todos`, `isLoading`, `isSubmitting`, `deletingId`, `addTodo`, and `deleteTodo` and subscribes to realtime updates via `subscribeToTodos`. 
- Update `app/screens/Home.jsx` to consume `useTodos`, simplify styles with `createStyles`, show focused loading/submitting/deleting states, trim/validate input, and disable buttons during operations. 
- Harden `firebase.config.js` to reuse an existing Firebase app instance with `firebase.apps.length ? firebase.app() : firebase.initializeApp(...)`. 
- Simplify theme initialization and toggling in `App.js` by loading storage once and using `useCallback` for the `themeHandler` and a single `THEME_STORAGE_KEY` constant.

### Testing
- Parsed updated source files with `@babel/parser` which succeeded for `App.js`, `firebase.config.js`, `app/screens/Home.jsx`, `app/hooks/useTodos.js`, and `app/services/todoService.js`. (passed) 
- Ran a runtime `import()` smoke-check of the new service which failed due to module resolution/ESM warnings for `firebase.config` in the environment. (failed) 
- Attempted `npx expo export --platform web` which failed because the local Expo CLI was not available in the environment. (failed) 
- Attempted `npm install` to run a dependency-based build but the run was blocked by a `403 Forbidden` when fetching `react-native@0.73.4`, preventing a full dependency install and end-to-end build. (failed)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69baf59e6a208320bfca17daac2d64b7)